### PR TITLE
`package.json` fix for `main` attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   ],
   "license": "MIT",
   "keywords": [],
-  "main": "index.js",
-  "jsnext:main": "index.es6.js",
+  "main": "dist/index.js",
+  "jsnext:main": "dist/index.es6.js",
   "babel": {
     "presets": [
       "es2015",


### PR DESCRIPTION
This PR solves what's reported on #99. I decided to change it to `dist/`, since `jsnext:main`'s `index.es6.js` is only generated when doing `npm run build`.
